### PR TITLE
修复cli命令不带参数报错

### DIFF
--- a/packages/cli/tasks/chaikaMergeTask/mergeFiles.js
+++ b/packages/cli/tasks/chaikaMergeTask/mergeFiles.js
@@ -9,7 +9,7 @@ const shelljs = require('shelljs');
 const mergeDir = path.join(cwd, '.CACHE/nanachi');
 let mergeFilesQueue = require('./mergeFilesQueue');
 let diff = require('deep-diff');
-const buildType = process.argv[2].split(':')[1];
+const buildType = process.argv.length > 2 ? process.argv[2].split(':')[1] : 'wx';
 const ignoreExt = ['.tgz'];
 const ANU_ENV = buildType
     ? buildType === 'h5'


### PR DESCRIPTION
# 直接运行不带参数的cli命令会报错
```
nanachi
/usr/local/share/.config/yarn/global/node_modules/nanachi-cli/tasks/chaikaMergeTask/mergeFiles.js:13
const buildType = process.argv[2].split(':')[1];
                                  ^

TypeError: Cannot read property 'split' of undefined
    at Object.<anonymous> (/usr/local/share/.config/yarn/global/node_modules/nanachi-cli/tasks/chaikaMergeTask/mergeFiles.js:13:35)
    at Module._compile (internal/modules/cjs/loader.js:1076:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
    at Module.load (internal/modules/cjs/loader.js:941:32)
    at Function.Module._load (internal/modules/cjs/loader.js:782:14)
    at Module.require (internal/modules/cjs/loader.js:965:19)
    at require (internal/modules/cjs/helpers.js:88:18)
    at Object.<anonymous> (/usr/local/share/.config/yarn/global/node_modules/nanachi-cli/tasks/chaikaMergeTask/index.js:23:38)
    at Module._compile (internal/modules/cjs/loader.js:1076:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1097:10)
```