### PR TITLE
修复runtimecommon.js文件引入路径错误问题

### DIFF
--- a/src/cli/packages/babelPlugins/collectCommonCode.ts
+++ b/src/cli/packages/babelPlugins/collectCommonCode.ts
@@ -67,10 +67,10 @@ const visitor = {
             if (!this.injectInportSpecifiers.length) return;
           
           
-            const importSourcePath = path.relative(
-                path.parse(utils.getDistPathFromSoucePath(state.filename)).dir,
+            const importSourcePath = utils.fixWinPath(path.relative(
+                path.parse(utils.getDistPathFromSoucePath(utils.fixWinPath(state.filename))).dir,
                 this.distCommonPath
-            );
+            ));
             const specifiersAst = this.injectInportSpecifiers.map(name => t.importSpecifier(t.identifier(name), t.identifier(name)));
             // from 'a/b/c' => from './a/b/c'
             const sourceAst = t.StringLiteral(


### PR DESCRIPTION
**主要出现了两个问题：**

1. `runtimecommon.js` 文件引入路径错误
2. `runtimecommon.js` 文件引入路径被转义为反双斜杠

根本原因都是Node获取的路径为反斜杠，把反斜杠转为正斜杠即可解决问题，下面是问题复现过程
<br>


**问题代码1**

```javascript
utils.getDistPathFromSoucePath(state.filename)
```

这里的代码是将source和npm里面的代码路径拼接到dist目录里面去

但由于路径是反斜杠的原因，路径会拼接错误

```javascript
期望效果：
"F:\mini\dist\pages\somePage\index.js"
"F:\mini\dist\npm\moment\index.js"

实际效果：
"F:\mini\dist\F:\mini\source\pages\somePage\index.js"
"F:\mini\dist\F:\mini\node_modules\moment\index.js"
```
![拼接错误](https://user-images.githubusercontent.com/35354987/136191507-a70be256-f147-4e1c-94e9-e21b08170b8f.png)

<br>


**问题代码2**

```javascript
const importSourcePath = path.relative(
    path.parse(utils.getDistPathFromSoucePath(state.filename)).dir,
    this.distCommonPath
)
```

这里的代码是将上面的绝对路径转换为相对路径，但是如果在这里一步不对路径进行正斜杠转换

下面的babel转换转出来的代码会变成反双斜杠

```javascript
期望效果：
import xxx from "../../internal/runtimecommon.js"

实际效果：
import xxx from "..\\..\\internal\\runtimecommon.js"
```



**解决：**

```javascript
const importSourcePath = utils.fixWinPath(path.relative(
	path.parse(utils.getDistPathFromSoucePath(utils.fixWinPath(state.filename))).dir,
	this.distCommonPath
));
```


**编译环境信息**

- nanachi-cli 版本：1.8.6
- nodejs版本、npm版本：[node v16.0.0、npm 7.11.1]
- 小程序IDE 版本: 最新
- 电脑操作系统： win10专业版 19042.1237

